### PR TITLE
com.nbeloglazov/hatnik-test-lib 0.2.4 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,4 +4,4 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [com.nbeloglazov/hatnik-test-lib "0.1.7"]])
+                 [com.nbeloglazov/hatnik-test-lib "0.2.4"]])


### PR DESCRIPTION
com.nbeloglazov/hatnik-test-lib 0.2.4 has been released. Previous version was 0.2.3.

This pull request is created on behalf of @nbeloglazov
