### PR TITLE
org.clojure/clojure 1.7.0-RC1 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,5 +3,5 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0-alpha6"]
+  :dependencies [[org.clojure/clojure "1.7.0-RC1"]
                  [com.nbeloglazov/hatnik-test-lib "0.2.4"]])


### PR DESCRIPTION
org.clojure/clojure 1.7.0-RC1 has been released. Previous version was 1.7.0-beta3.

This pull request is created on behalf of @nbeloglazov
